### PR TITLE
fix: ミッション遂行中のアイコンサイズを70%に縮小 (#18)

### DIFF
--- a/components/ActiveView.tsx
+++ b/components/ActiveView.tsx
@@ -229,7 +229,7 @@ export const ActiveView: React.FC<ActiveViewProps> = ({ tasks, departureTime, on
             <div
               className={`w-48 h-48 rounded-full flex items-center justify-center mb-2 shadow-2xl border-[14px] transition-all duration-300 bg-white ${isOvertime ? 'border-rose-500 animate-shake' : metrics.level === 'danger' ? 'border-rose-400' : metrics.level === 'warning' ? 'border-amber-400' : 'border-emerald-400'}`}
             >
-              <IconDisplay icon={currentTask.icon} size={90} className={visualConfig.text} />
+              <IconDisplay icon={currentTask.icon} size={63} className={visualConfig.text} />
             </div>
 
             <div className={`text-7xl font-black font-mono tabular-nums tracking-tighter drop-shadow-sm ${isOvertime ? 'text-rose-600 animate-pulse' : 'text-slate-800'}`}>


### PR DESCRIPTION
## 概要
Issue #18 の対応です。

## 変更内容
- ミッション遂行中の画面で表示されるミッションアイコンのサイズを90pxから63px（70%）に縮小
- これにより、画面上部の時間経過表示との重なりが解消されます

## 対象ファイル
- `components/ActiveView.tsx`

## 関連Issue
Closes #18