### PR TITLE
feat: 早起きボーナスチャンス機能を追加

### DIFF
--- a/components/CompletionView.tsx
+++ b/components/CompletionView.tsx
@@ -1,20 +1,37 @@
 import React, { useMemo } from 'react';
-import { Trophy, RotateCcw, Home } from 'lucide-react';
+import { Trophy, RotateCcw, Home, Zap, Star } from 'lucide-react';
 import { missionCompleteMessages, getRandomMessage } from '../randomMessages';
 
 interface CompletionViewProps {
+  isBonus: boolean;
+  isSuccess: boolean;
   onReset: () => void;
 }
 
-export const CompletionView: React.FC<CompletionViewProps> = ({ onReset }) => {
+export const CompletionView: React.FC<CompletionViewProps> = ({ isBonus, isSuccess, onReset }) => {
   // コンポーネントマウント時に1回だけランダムメッセージを生成
   const randomMessage = useMemo(() => getRandomMessage(missionCompleteMessages), []);
 
   return (
-    <div className="flex flex-col items-center justify-center h-full bg-gradient-to-b from-yellow-50 to-orange-100 p-6 text-center">
+    <div className={`flex flex-col items-center justify-center h-full p-6 text-center ${isBonus && isSuccess ? 'bg-gradient-to-b from-amber-100 via-yellow-50 to-orange-100' : 'bg-gradient-to-b from-yellow-50 to-orange-100'}`}>
       
-      <div className="mb-8 animate-bounce">
+      {/* ボーナス成功時の特別表示 */}
+      {isBonus && isSuccess && (
+        <div className="mb-4 flex items-center gap-2 bg-gradient-to-r from-amber-400 via-yellow-400 to-orange-400 text-white font-black text-lg py-2 px-6 rounded-full shadow-lg animate-bounce">
+          <Zap size={20} />
+          <span>早起きボーナス達成！ スタンプ 2個ゲット！</span>
+          <Zap size={20} />
+        </div>
+      )}
+
+      <div className="mb-8 animate-bounce relative">
         <Trophy size={120} className="text-yellow-500 drop-shadow-lg" />
+        {isBonus && isSuccess && (
+          <div className="absolute -top-2 -right-2 flex gap-1">
+            <Star size={28} fill="#f59e0b" className="text-amber-500 animate-spin" style={{ animationDuration: '3s' }} />
+            <Star size={28} fill="#f59e0b" className="text-amber-500 animate-spin" style={{ animationDuration: '2.5s' }} />
+          </div>
+        )}
       </div>
 
       <h1 className="text-4xl font-black text-orange-600 mb-4">
@@ -25,6 +42,12 @@ export const CompletionView: React.FC<CompletionViewProps> = ({ onReset }) => {
         {randomMessage}
       </p>
       
+      {isBonus && !isSuccess && (
+        <p className="text-sm text-orange-600/70 font-bold mb-2">
+          ボーナスチャンスだったけど、次はきっと間に合う！
+        </p>
+      )}
+
       <p className="text-lg text-orange-800/70 font-bold mb-12">
         いってらっしゃい！
       </p>

--- a/types.ts
+++ b/types.ts
@@ -38,6 +38,7 @@ export interface MissionLog {
   totalDurationSeconds: number; // Scheduled duration
   actualDurationSeconds?: number; // Actual measured duration
   isSuccess: boolean; // Completed before departure time
+  isBonus?: boolean; // 早起きボーナスチャンスだったか
 }
 
 export interface StampCard {


### PR DESCRIPTION
## 概要
出発時刻から十分早く起きた場合に「早起きボーナスチャンス」が発動し、ミッションクリア時にスタンプが2個もらえる機能を追加しました。

## 早起きボーナスの仕組み

### 判定条件
`現在時刻 < 出発時刻 - (タスク合計時間 + 10分)`

例: 出発8:00、タスク合計50分 → **7:00より前**に「おきた！」を押すとボーナス発動

### フロー
1. **「おきた！」ボタン押下時**にボーナス判定
2. **ボーナス発動** → 3秒間のフルスクリーン演出（⚡金色グラデーション＋星キラキラ）
3. **タスク遂行中** → ヘッダーに「⚡早起きボーナスチャンス！スタンプ2倍！⚡」バナーを常時表示
4. **ミッション完了時**:
   - 成功（出発時刻までに完了）→ **スタンプ2個ゲット**（通常は1個）
   - 失敗（出発時刻を過ぎた）→ **スタンプ0個** + 励ましメッセージ

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `types.ts` | `MissionLog` に `isBonus?: boolean` フラグを追加 |
| `components/RoutineManager.tsx` | `isBonus` ステート管理、スタンプ加算ロジック（ボーナス時+2）、props追加 |
| `components/ActiveView.tsx` | ボーナス判定ロジック、フルスクリーン演出、ヘッダーバナー表示 |
| `components/CompletionView.tsx` | ボーナス成功/失敗時の表示分岐 |

## 動作確認
- [x] ビルド成功
- [x] ボーナス判定ロジックの正常動作
- [x] 既存の通常フロー（ボーナス非発動時）への影響なし
- [x] LocalStorage の後方互換性（`isBonus` はオプショナル）