### PR TITLE
feat(rank): 称号システムを組み合わせ方式に拡張（4段階→35段階）

### DIFF
--- a/components/RewardView.tsx
+++ b/components/RewardView.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Medal, MissionLog } from '../types';
-import { Trophy, Star, Feather, Crown, Gift, ArrowRight } from 'lucide-react';
+import { Star, Gift, ArrowRight, ArrowUp } from 'lucide-react';
 import { generateRewardComment } from '../services/geminiService';
+import { getGrade, getRankClass, getRankTitle, isGradeUp, isMaxRank } from '../rankData';
 
 interface RewardViewProps {
     childName: string;
@@ -14,12 +15,12 @@ export const RewardView: React.FC<RewardViewProps> = ({ childName, rank, logs, o
     const [comment, setComment] = useState<string>('メッセージを作成中...');
     const [showContent, setShowContent] = useState(false);
 
-    const rankInfo = [
-        { title: 'ひよこポエム級', icon: <Feather size={48} />, color: 'text-yellow-500', bg: 'bg-yellow-50' },
-        { title: 'うさぎジャンプ級', icon: <Star size={48} />, color: 'text-sky-500', bg: 'bg-sky-50' },
-        { title: 'ライオンパワー級', icon: <Trophy size={48} />, color: 'text-orange-500', bg: 'bg-orange-50' },
-        { title: 'おうさまマスター級', icon: <Crown size={48} />, color: 'text-indigo-600', bg: 'bg-indigo-50' },
-    ][rank] || { title: 'すごい！', icon: <Star size={48} />, color: 'text-rose-500', bg: 'bg-rose-50' };
+    const grade = getGrade(rank);
+    const rankClass = getRankClass(rank);
+    const GradeIcon = grade.icon;
+    const title = getRankTitle(rank);
+    const gradeUp = isGradeUp(rank);
+    const maxRank = isMaxRank(rank);
 
     useEffect(() => {
         const fetchComment = async () => {
@@ -33,7 +34,7 @@ export const RewardView: React.FC<RewardViewProps> = ({ childName, rank, logs, o
     const handleGotIt = () => {
         const newMedal: Medal = {
             id: `medal-${Date.now()}`,
-            title: rankInfo.title,
+            title: title,
             date: new Date().toLocaleDateString('ja-JP'),
             comment: comment,
             rankAtTime: rank
@@ -43,7 +44,7 @@ export const RewardView: React.FC<RewardViewProps> = ({ childName, rank, logs, o
 
     return (
         <div className="fixed inset-0 z-50 flex flex-col items-center justify-center p-6 bg-white overflow-y-auto">
-            {/* Celebration Background Animation (Simplified) */}
+            {/* Celebration Background Animation */}
             <div className="absolute inset-0 pointer-events-none overflow-hidden">
                 {[...Array(20)].map((_, i) => (
                     <div
@@ -53,7 +54,7 @@ export const RewardView: React.FC<RewardViewProps> = ({ childName, rank, logs, o
                             left: `${Math.random() * 100}%`,
                             top: `${Math.random() * 100}%`,
                             animationDelay: `${Math.random() * 2}s`,
-                            color: ['#fbbf24', '#38bdf8', '#f87171', '#a78bfa'][i % 4]
+                            color: ['#fbbf24', '#38bdf8', '#f87171', '#a78bfa', '#34d399', '#f472b6'][i % 6]
                         }}
                     >
                         <Star size={Math.random() * 20 + 20} fill="currentColor" />
@@ -62,9 +63,25 @@ export const RewardView: React.FC<RewardViewProps> = ({ childName, rank, logs, o
             </div>
 
             <div className={`w-full max-w-md ${showContent ? 'animate-in fade-in zoom-in duration-500' : 'opacity-0'} flex flex-col items-center text-center space-y-8 z-10`}>
+                {/* グレードアップ時の特別バナー */}
+                {gradeUp && (
+                    <div className="flex items-center gap-2 bg-gradient-to-r from-amber-400 via-yellow-400 to-orange-400 text-white font-black text-sm py-2 px-5 rounded-full shadow-lg animate-bounce">
+                        <ArrowUp size={16} />
+                        <span>グレードアップ！ {grade.emoji} {grade.name}に進化！</span>
+                        <ArrowUp size={16} />
+                    </div>
+                )}
+
+                {/* MAX到達時の特別バナー */}
+                {maxRank && (
+                    <div className="flex items-center gap-2 bg-gradient-to-r from-violet-500 via-purple-500 to-indigo-500 text-white font-black text-sm py-2 px-5 rounded-full shadow-lg animate-pulse">
+                        <span>🎊 伝説の称号に到達！ 🎊</span>
+                    </div>
+                )}
+
                 <div className="relative">
-                    <div className={`w-32 h-32 rounded-full ${rankInfo.bg} flex items-center justify-center shadow-2xl border-4 border-white ring-4 ring-offset-2 ring-amber-400 animate-pulse`}>
-                        {rankInfo.icon}
+                    <div className={`w-32 h-32 rounded-full ${grade.bg} flex items-center justify-center shadow-2xl border-4 border-white ring-4 ring-offset-2 ${grade.ringColor} animate-pulse`}>
+                        <GradeIcon size={48} className={grade.stampColor} />
                     </div>
                     <div className="absolute -bottom-2 -right-2 bg-rose-500 text-white p-2 rounded-full shadow-lg">
                         <Gift size={24} />
@@ -73,9 +90,15 @@ export const RewardView: React.FC<RewardViewProps> = ({ childName, rank, logs, o
 
                 <div className="space-y-2">
                     <h2 className="text-3xl font-black text-slate-800">10回達成！</h2>
-                    <p className={`text-xl font-bold ${rankInfo.color} flex items-center justify-center gap-2`}>
-                        ランクアップ：{rankInfo.title}
+                    <p className={`text-xl font-bold ${grade.stampColor} flex items-center justify-center gap-2`}>
+                        ランクアップ：{title}
                     </p>
+                    {/* ★表示 */}
+                    <div className="flex items-center justify-center gap-1">
+                        {Array.from({ length: rankClass.stars }).map((_, i) => (
+                            <Star key={i} size={16} fill="currentColor" className="text-amber-400" />
+                        ))}
+                    </div>
                 </div>
 
                 <div className="bg-amber-50 rounded-3xl p-6 border-2 border-amber-200 shadow-inner relative mt-6">

--- a/components/RoutineManager.tsx
+++ b/components/RoutineManager.tsx
@@ -8,6 +8,7 @@ import { LogView } from './LogView';
 import { StampView } from './StampView';
 import { RewardView } from './RewardView';
 import { MissionLog, StampCard, Medal } from '../types';
+import { MAX_RANK } from '../rankData';
 
 /**
  * ローカルストレージから読み込んだタスクに type プロパティがない場合、
@@ -204,7 +205,7 @@ export const RoutineManager: React.FC<RoutineManagerProps> = ({ childId, initial
               ...prev,
               currentStamps: 0,
               totalRewards: prev.totalRewards + 1,
-              rank: Math.min(prev.rank + 1, 3),
+              rank: Math.min(prev.rank + 1, MAX_RANK),
               medals: [...prev.medals, medal]
             }));
             setMode('stamp');

--- a/components/StampView.tsx
+++ b/components/StampView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StampCard } from '../types';
-import { ArrowLeft, Star, Gift, Feather, Crown, Trophy, Medal as MedalIcon } from 'lucide-react';
+import { ArrowLeft, Star, Gift, Medal as MedalIcon } from 'lucide-react';
+import { getGrade, getRankClass, getRankTitle, getRankTitleShort, GRADES, CLASSES, getGradeIndex, getClassIndex, isMaxRank, TOTAL_RANKS } from '../rankData';
 
 interface StampViewProps {
     stampCard: StampCard;
@@ -12,18 +13,17 @@ export const StampView: React.FC<StampViewProps> = ({ stampCard, onBack, themeCo
     const totalSlots = 10;
     const currentStamps = stampCard.currentStamps;
 
-    const rankThemes = [
-        { title: 'ひよこポエム級', icon: <Feather size={20} />, cardColor: 'bg-yellow-400', stampColor: 'text-yellow-500', bg: 'bg-yellow-50' },
-        { title: 'うさぎジャンプ級', icon: <Star size={20} />, cardColor: 'bg-sky-400', stampColor: 'text-sky-500', bg: 'bg-sky-50' },
-        { title: 'ライオンパワー級', icon: <Trophy size={20} />, cardColor: 'bg-orange-400', stampColor: 'text-orange-500', bg: 'bg-orange-50' },
-        { title: 'おうさまマスター級', icon: <Crown size={20} />, cardColor: 'bg-indigo-600', stampColor: 'text-indigo-600', bg: 'bg-indigo-50' },
-    ];
-
-    const currentTheme = rankThemes[stampCard.rank] || rankThemes[0];
+    const grade = getGrade(stampCard.rank);
+    const rankClass = getRankClass(stampCard.rank);
+    const GradeIcon = grade.icon;
 
     const colorClass = themeColor === 'rose' ? 'text-rose-600' : 'text-sky-600';
     const bgClass = themeColor === 'rose' ? 'bg-rose-50' : 'bg-sky-50';
     const buttonClass = themeColor === 'rose' ? 'bg-rose-500 hover:bg-rose-600' : 'bg-sky-500 hover:bg-sky-600';
+
+    // ランクの進捗計算
+    const currentGradeIdx = getGradeIndex(stampCard.rank);
+    const currentClassIdx = getClassIndex(stampCard.rank);
 
     return (
         <div className={`flex-1 flex flex-col h-full ${bgClass} overflow-y-auto pb-10`}>
@@ -40,14 +40,14 @@ export const StampView: React.FC<StampViewProps> = ({ stampCard, onBack, themeCo
             <div className="flex-1 p-6 flex flex-col items-center">
 
                 {/* Rank & Reward Summary */}
-                <div className="mb-8 flex gap-3 w-full max-w-sm">
+                <div className="mb-4 flex gap-3 w-full max-w-sm">
                     <div className="flex-1 bg-white p-4 rounded-2xl shadow-sm flex items-center gap-3">
-                        <div className={`p-2 rounded-full ${currentTheme.bg}`}>
-                            <div className={currentTheme.stampColor}>{currentTheme.icon}</div>
+                        <div className={`p-2 rounded-full ${grade.bg}`}>
+                            <div className={grade.stampColor}><GradeIcon size={20} /></div>
                         </div>
                         <div className="flex flex-col">
                             <span className="text-[10px] font-bold text-gray-500 uppercase tracking-wider">現在のランク</span>
-                            <span className={`text-sm font-black text-slate-700`}>{currentTheme.title}</span>
+                            <span className={`text-sm font-black text-slate-700`}>{getRankTitleShort(stampCard.rank)}</span>
                         </div>
                     </div>
                     <div className="flex-1 bg-white p-4 rounded-2xl shadow-sm flex items-center gap-3">
@@ -61,9 +61,61 @@ export const StampView: React.FC<StampViewProps> = ({ stampCard, onBack, themeCo
                     </div>
                 </div>
 
+                {/* Rank Progress - グレード & クラスの進捗表示 */}
+                <div className="mb-8 w-full max-w-sm bg-white rounded-2xl shadow-sm p-4">
+                    <div className="flex items-center justify-between mb-3">
+                        <span className="text-[10px] font-bold text-gray-500 uppercase tracking-wider">ランクの旅</span>
+                        <span className="text-xs font-bold text-gray-400">
+                            {stampCard.rank + 1} / {TOTAL_RANKS}
+                        </span>
+                    </div>
+
+                    {/* グレード進捗（動物アイコン並び） */}
+                    <div className="flex items-center justify-between mb-3">
+                        {GRADES.map((g, idx) => {
+                            const Icon = g.icon;
+                            const reached = idx <= currentGradeIdx;
+                            return (
+                                <div key={idx} className="flex flex-col items-center gap-1">
+                                    <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm ${
+                                        reached ? g.bg + ' ' + g.stampColor : 'bg-gray-100 text-gray-300'
+                                    } ${idx === currentGradeIdx ? 'ring-2 ring-offset-1 ' + g.ringColor : ''}`}>
+                                        <Icon size={16} />
+                                    </div>
+                                    <span className={`text-[9px] font-bold ${reached ? 'text-gray-600' : 'text-gray-300'}`}>
+                                        {g.emoji}
+                                    </span>
+                                </div>
+                            );
+                        })}
+                    </div>
+
+                    {/* クラス進捗（★の数） */}
+                    <div className="flex items-center gap-1 justify-center">
+                        {CLASSES.map((cls, idx) => (
+                            <div key={idx} className="flex flex-col items-center gap-0.5">
+                                <Star
+                                    size={18}
+                                    fill={idx <= currentClassIdx ? 'currentColor' : 'none'}
+                                    className={idx <= currentClassIdx ? grade.stampColor : 'text-gray-200'}
+                                />
+                                <span className={`text-[8px] font-bold ${idx <= currentClassIdx ? 'text-gray-500' : 'text-gray-300'}`}>
+                                    {cls.name}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+
+                    {isMaxRank(stampCard.rank) && (
+                        <div className="mt-3 text-center text-xs font-black text-amber-600 bg-amber-50 py-1 rounded-full">
+                            🎊 全称号コンプリート！伝説のおうさま！ 🎊
+                        </div>
+                    )}
+                </div>
+
                 {/* Stamp Card */}
                 <div className="bg-white rounded-3xl shadow-xl p-6 w-full max-w-sm flex flex-col relative overflow-hidden mb-12">
-                    <div className={`absolute top-0 left-0 w-full h-4 ${currentTheme.cardColor}`} />
+                    <div className={`absolute top-0 left-0 w-full h-4 ${grade.cardColor}`} />
 
                     <h3 className="text-center font-bold text-gray-700 mb-6 mt-2 text-lg">
                         あさのミッション・スタンプ
@@ -79,7 +131,7 @@ export const StampView: React.FC<StampViewProps> = ({ stampCard, onBack, themeCo
                                     key={idx}
                                     className={`
                                         aspect-square relative rounded-xl border-2 border-dashed flex items-center justify-center
-                                        ${isStamped ? (currentTheme.bg + ' border-transparent') : 'border-gray-100 bg-gray-50/50'}
+                                        ${isStamped ? (grade.bg + ' border-transparent') : 'border-gray-100 bg-gray-50/50'}
                                     `}
                                 >
                                     {isStamped ? (
@@ -87,7 +139,7 @@ export const StampView: React.FC<StampViewProps> = ({ stampCard, onBack, themeCo
                                             <Star
                                                 size={isLast ? 28 : 24}
                                                 fill="currentColor"
-                                                className={`${currentTheme.stampColor} drop-shadow-sm`}
+                                                className={`${grade.stampColor} drop-shadow-sm`}
                                             />
                                         </div>
                                     ) : (
@@ -105,7 +157,10 @@ export const StampView: React.FC<StampViewProps> = ({ stampCard, onBack, themeCo
                     </div>
 
                     <div className="mt-6 text-center text-xs text-gray-400 font-bold">
-                        あと {totalSlots - currentStamps} 個でランクアップ！
+                        {isMaxRank(stampCard.rank)
+                            ? `あと ${totalSlots - currentStamps} 個でごほうび！`
+                            : `あと ${totalSlots - currentStamps} 個でランクアップ！`
+                        }
                     </div>
                 </div>
 
@@ -122,24 +177,28 @@ export const StampView: React.FC<StampViewProps> = ({ stampCard, onBack, themeCo
                         </div>
                     ) : (
                         <div className="space-y-3">
-                            {stampCard.medals.slice().reverse().map((medal) => (
-                                <div key={medal.id} className="bg-white rounded-2xl p-4 shadow-sm border border-gray-100 flex gap-4">
-                                    <div className={`w-12 h-12 rounded-full flex-shrink-0 flex items-center justify-center ${rankThemes[medal.rankAtTime]?.bg || 'bg-gray-50'}`}>
-                                        <div className={rankThemes[medal.rankAtTime]?.stampColor || 'text-gray-400'}>
-                                            {rankThemes[medal.rankAtTime]?.icon || <Star size={24} />}
+                            {stampCard.medals.slice().reverse().map((medal) => {
+                                const medalGrade = getGrade(medal.rankAtTime);
+                                const MedalGradeIcon = medalGrade.icon;
+                                return (
+                                    <div key={medal.id} className="bg-white rounded-2xl p-4 shadow-sm border border-gray-100 flex gap-4">
+                                        <div className={`w-12 h-12 rounded-full flex-shrink-0 flex items-center justify-center ${medalGrade.bg}`}>
+                                            <div className={medalGrade.stampColor}>
+                                                <MedalGradeIcon size={20} />
+                                            </div>
+                                        </div>
+                                        <div className="flex-1 space-y-1">
+                                            <div className="flex justify-between items-start">
+                                                <h4 className="font-black text-slate-700 text-sm">{medal.title}</h4>
+                                                <span className="text-[10px] font-bold text-gray-400">{medal.date}</span>
+                                            </div>
+                                            <p className="text-xs text-slate-500 font-medium leading-relaxed italic">
+                                                "{medal.comment}"
+                                            </p>
                                         </div>
                                     </div>
-                                    <div className="flex-1 space-y-1">
-                                        <div className="flex justify-between items-start">
-                                            <h4 className="font-black text-slate-700 text-sm">{medal.title}</h4>
-                                            <span className="text-[10px] font-bold text-gray-400">{medal.date}</span>
-                                        </div>
-                                        <p className="text-xs text-slate-500 font-medium leading-relaxed italic">
-                                            "{medal.comment}"
-                                        </p>
-                                    </div>
-                                </div>
-                            ))}
+                                );
+                            })}
                         </div>
                     )}
                 </div>

--- a/rankData.ts
+++ b/rankData.ts
@@ -1,0 +1,104 @@
+import { Feather, Star, Trophy, Crown, Cat, Flame, Sparkles, type LucideIcon } from 'lucide-react';
+
+// ============================================================
+// 称号システム: 「グレード（動物）× クラス（二つ名）」の組み合わせ方式
+// グレード 7種 × クラス 5種 = 35段階
+// 10回達成ごとにクラスが上がり、クラスが一周するとグレードが上がる
+// → 350回で全称号コンプリート（≒1年以上遊べる）
+// ============================================================
+
+// --- グレード定義（動物の進化） ---
+export interface Grade {
+  name: string;         // 動物名
+  emoji: string;        // 表示用絵文字
+  icon: LucideIcon;     // lucide アイコン
+  cardColor: string;    // スタンプカード上部の色
+  stampColor: string;   // スタンプの色クラス
+  bg: string;           // 背景色クラス
+  ringColor: string;    // RewardView のリングカラー
+}
+
+export const GRADES: Grade[] = [
+  { name: 'ひよこ',     emoji: '🐣', icon: Feather,   cardColor: 'bg-yellow-400',  stampColor: 'text-yellow-500',  bg: 'bg-yellow-50',  ringColor: 'ring-yellow-400' },
+  { name: 'うさぎ',     emoji: '🐰', icon: Star,      cardColor: 'bg-sky-400',     stampColor: 'text-sky-500',     bg: 'bg-sky-50',     ringColor: 'ring-sky-400' },
+  { name: 'ねこ',       emoji: '🐱', icon: Cat,       cardColor: 'bg-pink-400',    stampColor: 'text-pink-500',    bg: 'bg-pink-50',    ringColor: 'ring-pink-400' },
+  { name: 'ライオン',   emoji: '🦁', icon: Trophy,    cardColor: 'bg-orange-400',  stampColor: 'text-orange-500',  bg: 'bg-orange-50',  ringColor: 'ring-orange-400' },
+  { name: 'ドラゴン',   emoji: '🐉', icon: Flame,     cardColor: 'bg-red-500',     stampColor: 'text-red-500',     bg: 'bg-red-50',     ringColor: 'ring-red-500' },
+  { name: 'ユニコーン', emoji: '🦄', icon: Sparkles,  cardColor: 'bg-violet-500',  stampColor: 'text-violet-500',  bg: 'bg-violet-50',  ringColor: 'ring-violet-500' },
+  { name: 'おうさま',   emoji: '👑', icon: Crown,     cardColor: 'bg-indigo-600',  stampColor: 'text-indigo-600',  bg: 'bg-indigo-50',  ringColor: 'ring-amber-400' },
+];
+
+// --- クラス定義（二つ名の進化） ---
+export interface RankClass {
+  name: string;       // 二つ名
+  stars: number;      // 表示用★の数（1〜5）
+}
+
+export const CLASSES: RankClass[] = [
+  { name: 'ルーキー',       stars: 1 },
+  { name: 'ファイター',     stars: 2 },
+  { name: 'エース',         stars: 3 },
+  { name: 'チャンピオン',   stars: 4 },
+  { name: 'マスター',       stars: 5 },
+];
+
+export const TOTAL_RANKS = GRADES.length * CLASSES.length; // 35
+export const MAX_RANK = TOTAL_RANKS - 1;                   // 34
+
+// --- ヘルパー関数 ---
+
+/** rank を 0〜MAX_RANK の安全な範囲にクランプする（localStorage 破損対策） */
+const safeRank = (rank: number): number => {
+  return Math.max(0, Math.min(Math.floor(rank), MAX_RANK));
+};
+
+/** rank 番号 (0〜34) → グレード index (0〜6) */
+export const getGradeIndex = (rank: number): number => {
+  return Math.floor(safeRank(rank) / CLASSES.length);
+};
+
+/** rank 番号 (0〜34) → クラス index (0〜4) */
+export const getClassIndex = (rank: number): number => {
+  return safeRank(rank) % CLASSES.length;
+};
+
+/** rank 番号 (0〜34) → グレード定義 */
+export const getGrade = (rank: number): Grade => {
+  return GRADES[getGradeIndex(rank)];
+};
+
+/** rank 番号 (0〜34) → クラス定義 */
+export const getRankClass = (rank: number): RankClass => {
+  return CLASSES[getClassIndex(rank)];
+};
+
+/** rank 番号 (0〜34) → 称号文字列（例:「ひよこ ルーキー級」） */
+export const getRankTitle = (rank: number): string => {
+  const grade = getGrade(rank);
+  const cls = getRankClass(rank);
+  return `${grade.emoji} ${grade.name}${cls.name}級`;
+};
+
+/** rank 番号 (0〜34) → 称号文字列（絵文字なし、コンパクト表示用） */
+export const getRankTitleShort = (rank: number): string => {
+  const grade = getGrade(rank);
+  const cls = getRankClass(rank);
+  return `${grade.name}${cls.name}級`;
+};
+
+/** クラスが一周してグレードが上がったか（特別演出用） */
+export const isGradeUp = (rank: number): boolean => {
+  return rank > 0 && getClassIndex(rank) === 0;
+};
+
+/** 最高ランクに到達済みか */
+export const isMaxRank = (rank: number): boolean => {
+  return rank >= MAX_RANK;
+};
+
+// --- 旧データとの互換マッピング ---
+// 旧: rank 0=ひよこ, 1=うさぎ, 2=ライオン, 3=おうさま
+// 新: rank 0〜4=ひよこ系, 5〜9=うさぎ系, 10〜14=ねこ系, 15〜19=ライオン系, ...
+// 旧 rank 値 (0〜3) はそのまま新 rank としても正しく動作する
+// （旧0=ひよこルーキー, 旧1=ひよこファイター, 旧2=ひよこエース, 旧3=ひよこチャンピオン）
+// これにより既存ユーザーのデータが壊れることはない

--- a/types.ts
+++ b/types.ts
@@ -44,7 +44,7 @@ export interface MissionLog {
 export interface StampCard {
   currentStamps: number;
   totalRewards: number;
-  rank: number; // 0: ひよこ, 1: うさぎ, 2: ライオン, 3: おうさま
+  rank: number; // 0〜34: グレード(動物)×クラス(二つ名)の組み合わせ（詳細は rankData.ts 参照）
   medals: Medal[];
 }
 


### PR DESCRIPTION
## 概要
お子さんが称号MAXに到達しそうとのことで、称号システムを大幅に拡張しました。

## アプローチ: 組み合わせ方式
単にハードコードで称号を増やすのではなく、**グレード（動物）× クラス（二つ名）** の組み合わせで称号を生成する仕組みにしました。

### グレード（7種の動物）
🐣 ひよこ → 🐰 うさぎ → 🐱 ねこ → 🦁 ライオン → 🐉 ドラゴン → 🦄 ユニコーン → 👑 おうさま

### クラス（5種の二つ名）
★ ルーキー → ★★ ファイター → ★★★ エース → ★★★★ チャンピオン → ★★★★★ マスター

### 結果
- **7 × 5 = 35段階** の称号（旧: 4段階）
- 10回達成ごとにクラスアップ、クラスが一周するとグレードアップ
- **350回達成で全称号コンプリート**（≒1年以上遊べます）
- 称号の追加は配列に要素を足すだけで簡単に拡張可能

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `rankData.ts` (新規) | グレード・クラスの定義とヘルパー関数 |
| `StampView.tsx` | グレード&クラスの進捗マップ表示を追加 |
| `RewardView.tsx` | グレードアップ時の特別演出を追加 |
| `RoutineManager.tsx` | ランク上限を3→34(MAX_RANK)に変更 |
| `types.ts` | rank フィールドのコメント更新 |

## 後方互換性
既存ユーザーのデータ（rank 0〜3）はそのまま新システムでも正しく動作します。

## 将来の拡張
グレードやクラスの配列に要素を追加するだけで、さらに称号を増やせます。