### PR TITLE
fix: ランクアップがAIコメント失敗時に止まる問題を修正

### DIFF
--- a/components/RewardView.tsx
+++ b/components/RewardView.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { Medal, MissionLog } from '../types';
 import { Star, Gift, ArrowRight, ArrowUp } from 'lucide-react';
 import { generateRewardComment } from '../services/geminiService';
 import { getGrade, getRankClass, getRankTitle, isGradeUp, isMaxRank, TOTAL_RANKS } from '../rankData';
 
 const TOTAL_STAMP_SLOTS = 15;
+const AI_COMMENT_TIMEOUT_MS = 10000; // AIコメント取得のタイムアウト（10秒）
+const FALLBACK_COMMENT = '毎日の積み重ねが素晴らしいよ！これからも応援しているよ！';
 
 interface RewardViewProps {
     childName: string;
@@ -16,6 +18,7 @@ interface RewardViewProps {
 export const RewardView: React.FC<RewardViewProps> = ({ childName, rank, logs, onAccept }) => {
     const [comment, setComment] = useState<string>('メッセージを作成中...');
     const [showContent, setShowContent] = useState(false);
+    const isMounted = useRef(true);
 
     const grade = getGrade(rank);
     const rankClass = getRankClass(rank);
@@ -25,12 +28,34 @@ export const RewardView: React.FC<RewardViewProps> = ({ childName, rank, logs, o
     const maxRank = isMaxRank(rank);
 
     useEffect(() => {
+        isMounted.current = true;
+
         const fetchComment = async () => {
-            const msg = await generateRewardComment(childName, logs);
-            setComment(msg);
-            setShowContent(true);
+            try {
+                // AIコメント取得にタイムアウトを設定
+                const timeoutPromise = new Promise<string>((_, reject) =>
+                    setTimeout(() => reject(new Error('AI comment timeout')), AI_COMMENT_TIMEOUT_MS)
+                );
+                const commentPromise = generateRewardComment(childName, logs);
+                const msg = await Promise.race([commentPromise, timeoutPromise]);
+                if (isMounted.current) {
+                    setComment(msg);
+                }
+            } catch (error) {
+                console.error('AI comment failed, using fallback:', error);
+                if (isMounted.current) {
+                    setComment(FALLBACK_COMMENT);
+                }
+            } finally {
+                // コメント成功・失敗に関わらず、必ずコンテンツを表示する
+                if (isMounted.current) {
+                    setShowContent(true);
+                }
+            }
         };
         fetchComment();
+
+        return () => { isMounted.current = false; };
     }, [childName, logs]);
 
     const handleGotIt = () => {

--- a/components/RoutineManager.tsx
+++ b/components/RoutineManager.tsx
@@ -105,11 +105,24 @@ export const RoutineManager: React.FC<RoutineManagerProps> = ({ childId, initial
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [mode]);
 
-  // missionMode が切り替わったときは setup に戻す
+  // missionMode が切り替わったときは setup に戻す（ランクアップ未処理チェック付き）
   useEffect(() => {
-    setMode('setup');
     setIsBonus(false);
+    // missionMode 切替時にもランクアップ未処理があれば reward に遷移
+    if (stampCard.currentStamps >= TOTAL_STAMP_SLOTS) {
+      setMode('reward');
+    } else {
+      setMode('setup');
+    }
   }, [missionMode]);
+
+  // アプリ読み込み完了時にランクアップ未処理があれば自動的に reward 画面へ遷移
+  // （ブラウザリロードなどでランクアップが中断された場合のリカバリー）
+  useEffect(() => {
+    if (isLoaded && stampCard.currentStamps >= TOTAL_STAMP_SLOTS && mode === 'setup') {
+      setMode('reward');
+    }
+  }, [isLoaded, stampCard.currentStamps, mode]);
 
   // --- 朝/夜で切り替わる変数をここで一元定義 ---
   const currentTasks = isNight ? nightTasks : tasks;

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -3,6 +3,9 @@ import { Task, TaskIcon, TaskType, MissionLog } from '../types';
 
 const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
 
+// フォールバック用コメント（AIコメント取得失敗時に使用）
+const FALLBACK_REWARD_COMMENT = '毎日の積み重ねが素晴らしいよ！これからも応援しているよ！';
+
 export const generateSchedule = async (promptText: string): Promise<Task[]> => {
   try {
     const response = await ai.models.generateContent({
@@ -56,6 +59,12 @@ export const generateSchedule = async (promptText: string): Promise<Task[]> => {
 
 export const generateRewardComment = async (childName: string, logs: MissionLog[]): Promise<string> => {
   try {
+    // API キーが未設定の場合は早期リターン
+    if (!process.env.API_KEY) {
+      console.warn('API_KEY is not set, using fallback reward comment');
+      return FALLBACK_REWARD_COMMENT;
+    }
+
     // 最近の10件の実績を分析対象にする
     const recentLogs = logs.slice(-10);
     const successCount = recentLogs.filter(l => l.isSuccess).length;
@@ -81,10 +90,10 @@ export const generateRewardComment = async (childName: string, logs: MissionLog[
       `
     });
 
-    return response.text || "いつも頑張っているね！これからも応援しているよ！";
+    return response.text || FALLBACK_REWARD_COMMENT;
   } catch (error) {
     console.error("Gemini Reward Comment Error:", error);
-    return "10回達成おめでとう！毎日の積み重ねが素晴らしいよ！";
+    return FALLBACK_REWARD_COMMENT;
   }
 };
 


### PR DESCRIPTION
## 問題

スタンプが15個たまった際、以下の問題が発生していました：

### 1. AIコメントが出ないとランクアップ画面が表示されない
`RewardView` で `generateRewardComment` (Gemini API) のコメント取得が失敗すると、`showContent` が `false` のままになり、ランクアップ画面全体が `opacity: 0` で描画され、ユーザーには何も表示されない状態になっていました。

**原因**: `useEffect` 内の `fetchComment` で `await` が解決しない場合（APIキー未設定、ネットワークエラー等）、`setShowContent(true)` に到達しないため。

### 2. ランクアップ未処理のリカバリーがない
ブラウザリロードや朝/夜モード切替時に、スタンプ15個以上たまった状態でも `setup` 画面に戻されてしまい、ランクアップ処理が実行されませんでした。

## 修正内容

### RewardView.tsx
- AIコメント取得に **10秒タイムアウト** (`Promise.race`) を追加
- `try/catch/finally` 構造に変更し、**成功・失敗に関わらず必ず `showContent = true`** にしてランクアップ画面を表示
- コンポーネントのアンマウント対策として `useRef(isMounted)` を追加
- フォールバックメッセージを定数化

### RoutineManager.tsx
- **アプリ読み込み完了時** (`isLoaded`): `currentStamps >= 15` の場合、自動的に `reward` 画面へ遷移（リロード時のリカバリー）
- **missionMode 切替時**: 同様に未処理ランクアップを検出して `reward` 画面へ遷移

### geminiService.ts
- `generateRewardComment`: **API\_KEY 未設定時に早期リターン** し、API呼び出しをスキップしてフォールバックメッセージを即座に返す

## テスト観点
- [x] ビルド成功確認
- [x] APIキー未設定時にフォールバックメッセージが即座に返される
- [x] スタンプ15個でランクアップ画面が必ず表示される
- [x] ブラウザリロード後も未処理ランクアップがリカバリーされる