### PR TITLE
朝ミッション画面: 残り時間と余裕時間の表示を入れ替え

### DIFF
--- a/components/ActiveView.tsx
+++ b/components/ActiveView.tsx
@@ -413,17 +413,17 @@ export const ActiveView: React.FC<ActiveViewProps> = ({ tasks, departureTime, is
           />
           <div className="absolute inset-0 flex items-center justify-between px-3 text-xs font-black text-slate-700 drop-shadow-sm pointer-events-none">
             <span className="bg-white/50 px-1 rounded">残り: {Math.ceil(metrics.remainingTaskMinutes)}分</span>
-            <span className="bg-white/50 px-1 rounded">出発まで: {Math.max(0, Math.ceil(metrics.minutesToDeparture))}分</span>
+            <span className={`bg-white/50 px-1 rounded ${visualConfig.text}`}>
+              {metrics.diffMinutes >= 0 ? 'よゆう' : 'たりない'}: {Math.abs(metrics.diffMinutes)}分
+            </span>
           </div>
         </div>
 
-        {/* バッファ表示 */}
+        {/* 出発までの残り時間表示（メイン） */}
         <div className="text-center font-bold text-sm">
-          {metrics.diffMinutes >= 0 ? (
-            <span className="text-emerald-700">あと <span className="text-xl">{metrics.diffMinutes}</span> ふん よゆうがあるよ！</span>
-          ) : (
-            <span className="text-rose-700"><span className="text-xl">{Math.abs(metrics.diffMinutes)}</span> ふん たりない！！</span>
-          )}
+          <span className={visualConfig.text}>
+            しゅっぱつまで あと <span className="text-xl">{Math.max(0, Math.ceil(metrics.minutesToDeparture))}</span> ふん！
+          </span>
         </div>
       </div>
 


### PR DESCRIPTION
## 概要
朝ミッション画面で「あと○分余裕があるよ」と「残り○分」の表示位置を入れ替えました。

## 背景・目的
使っている子供が「あと何分余裕がある」という増えていく数字を意識しがちで、本来気にしてほしい **出発までの残り時間** への意識が弱くなっていた。
残り時間を主役に据えることで、時間感覚を養えるUIにする。

## 変更内容
`components/ActiveView.tsx`

### Before
- **メインの大きい表示**: 「あと ○ ふん よゆうがあるよ！」（余裕時間）
- **メーター内の小さい表示**: 「残り: ○分」（タスク合計時間）/「出発まで: ○分」

### After
- **メインの大きい表示**: 「しゅっぱつまで あと ○ ふん！」（出発までの残り時間）
  - 緊急度に応じて文字色が変化（safe=通常 / warning=オレンジ / danger=赤）
- **メーター内の小さい表示**: 「残り: ○分」（タスク合計時間）/「よゆう: ○分」（緑） or 「たりない: ○分」（赤）

## 効果
- 残り時間が一番目立つ位置に来るので、子供が出発時刻を意識しやすくなる
- 「よゆう」表示は小さく残しているので、ミッションを終えて余裕が増える達成感も維持
- 緊急度に応じた色の変化で、危険・警告が直感的に伝わる

## 動作確認
- `npm run build` 成功
- 既存のメトリクス計算ロジックには手を加えていないため、表示のみの変更